### PR TITLE
Deal with classmethod being no longer able to wrap @property and similar in Python 3.13

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.10"] # this project uses 3.9 features (but rcon needs 3.10)
+        python: ["3.13"] # this project uses 3.9 features (but rcon needs 3.10)
 
         include:
           - os: "ubuntu-latest"
-            python: "3.10"
+            python: "3.13"
             publish: true
 
     name: build/${{ matrix.python }}/${{ matrix.os }}

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Wheel and Sdist as artifacts
         if: matrix.publish
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*
@@ -66,7 +66,7 @@ jobs:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
     # upload to PyPI and make a release on every tag
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/mcwb/blocks.py
+++ b/mcwb/blocks.py
@@ -31,16 +31,16 @@ class Blocks:
         self.position = position
 
         if isinstance(cube, np.ndarray):
-            self.ncube: np.ndarray = cube
+            self.ncube = cube
         else:
-            self.ncube: np.ndarray = np.array(cube, dtype=Item)
+            self.ncube = np.array(cube, dtype=Item)
 
         self._create()
 
         if render:
             self._render()
 
-    def _create(self):
+    def _create(self) -> None:
         if self.ncube.ndim != 3:
             raise ValueError("invalid cube specification")
 
@@ -109,7 +109,7 @@ class Blocks:
 
     def to_cuboid(self) -> Cuboid:
         """return the blocks' contents as a Cuboid"""
-        return self.ncube.tolist()
+        return self.ncube.tolist() # type: ignore
 
     def save_blocks(self, file: Path) -> None:
         """save the blocks to a file"""

--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -89,16 +89,14 @@ def validate(items: Items):
     """
     Validates a row, profile or cuboid, ensuring consistent dimensions
     """
-    ragged = False
+    invalid = False
 
-    # np ragged array is deprecated but only supplys a warning currently
-    with np.warnings.catch_warnings(record=True) as warning:
-        np.warnings.simplefilter("always")
+    try:
         n_array = np.array(items)
-        if warning and "ragged nested" in str(warning[-1].message):
-            ragged = True
+    except ValueError:
+        invalid = True
 
-    return int(n_array.ndim) if not ragged else 0
+    return int(n_array.ndim) if not invalid else 0
 
 
 def shift(arr: np.ndarray, vec: Vec3, fill: Item = Item.AIR) -> np.ndarray:

--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -1,6 +1,7 @@
 """Helper functions."""
 
 from typing import Iterator, Union
+import typing
 
 import numpy as np
 from mcipc.rcon.enumerations import Item
@@ -98,7 +99,12 @@ def validate(items: Items):
 
     return int(n_array.ndim) if not invalid else 0
 
-
+# This results in a lot of
+# error: Slice index must be an integer, SupportsIndex or None
+# Invalid index type "tuple[slice[None, None, None], slice[None, float | int, None], slice[None, None, None]]" 
+#   for "ndarray[Any, Any]"; expected type "ndarray[tuple[int, ...], dtype[integer[Any] | numpy.bool[builtins.bool]]] 
+#   | tuple[ndarray[tuple[int, ...], dtype[integer[Any] | numpy.bool[builtins.bool]]], ...]"  [index]
+@typing.no_type_check
 def shift(arr: np.ndarray, vec: Vec3, fill: Item = Item.AIR) -> np.ndarray:
     """shift a 3d array of Item by vec, discarding the cells that are
     shifted out and filling the new space with Item fill

--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -50,9 +50,9 @@ def get_direction(start: Vec3, end: Vec3) -> Vec3:
 def y_rotate(direction: Vec3, clockwise: bool = True) -> Vec3:
     """rotate a cardinal direction about the y axis"""
 
-    current = Direction.cardinals.index(direction)
+    current = Direction.cardinals().index(direction)
     rotated = current + (1 if clockwise else -1)
-    return Direction.cardinals[rotated % len(Direction.cardinals)]
+    return Direction.cardinals()[rotated % len(Direction.cardinals())]
 
 
 def normalize(

--- a/mcwb/itemlists.py
+++ b/mcwb/itemlists.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
+from numpy.typing import NDArray
 from mcipc.rcon.enumerations import Item
 from mcipc.rcon.je import Client
 
@@ -26,7 +27,7 @@ def save_items(items: Items, filename: Path) -> None:
     """save a Profile, Cuboid or Row to a json file"""
 
     if isinstance(items, np.ndarray):
-        items = items.tolist()
+        items = items.tolist() # type: ignore
 
     def json_item(item: Item):
         return {ITEM_KEY: item.value}
@@ -44,7 +45,7 @@ def save_items(items: Items, filename: Path) -> None:
     )
 
 
-def load_items(filename: Union[Path, str], dimensions: int = None) -> Items:
+def load_items(filename: Union[Path, str], dimensions: int = 0) -> Items:
     """load a JSON file of Items - returns a Cuboid, Profile or Row"""
 
     def as_item(dct: dict):
@@ -61,7 +62,7 @@ def load_items(filename: Union[Path, str], dimensions: int = None) -> Items:
     if valid_dims == 0:
         raise ValueError("file {filename} contains invalid JSON")
 
-    if dimensions is not None and valid_dims != dimensions:
+    if dimensions != 0 and valid_dims != dimensions:
         raise ValueError(
             "file {filename} contains {valid_dims} dimension Items"
             "but {dimensions} dimensions was requested"
@@ -72,10 +73,10 @@ def load_items(filename: Union[Path, str], dimensions: int = None) -> Items:
 
 def grab(client: Client, vol: Volume) -> Cuboid:
     """copy blocks from a Volume in the minecraft world into a cuboid of Item"""
-    cube = np.ndarray(vol.size.i_tuple, dtype=Item)
+    cube: NDArray[Item] = np.ndarray(vol.size.i_tuple, dtype=Item)
 
     for idx, _ in np.ndenumerate(cube):
         cube[idx] = get_block(client, vol.start + Vec3(*idx))
 
     result = cube.tolist()
-    return result
+    return result # type: ignore

--- a/mcwb/types.py
+++ b/mcwb/types.py
@@ -250,23 +250,20 @@ class Direction:
 
     # An indexed lookup like an Enum, useful for quadrant math
     @classmethod
-    @property
     def values(cls) -> List[Vec3]:
         return [cls.SOUTH, cls.WEST, cls.NORTH, cls.EAST, cls.UP, cls.DOWN]
 
     @classmethod
-    @property
     def all(cls) -> List[Vec3]:
         return [val for val in vars(cls).values() if isinstance(val, Vec3)]
 
     @classmethod
-    @property
     def cardinals(cls) -> List[Vec3]:
-        return list(cls.all[:-2])
+        return list(cls.all()[:-2])
 
     @classmethod
     def name(cls, direction: Vec3) -> str:
-        idx = cls.all.index(direction)
+        idx = cls.all().index(direction)
         return cls._names[idx]
 
     @classmethod
@@ -280,7 +277,7 @@ class Direction:
         angle /= pi / 2
         quarter = int(angle)
         quarter = (quarter + 1) % 4
-        return cls.values[quarter]
+        return cls.values()[quarter]
 
 
 class Planes3d(Enum):

--- a/mcwb/types.py
+++ b/mcwb/types.py
@@ -113,14 +113,14 @@ class Vec3(NamedTuple):
 
         return type(self)(self.x // other, self.y // other, self.z // other)
 
-    def __getitem__(self, index_or_key: Union[int, str]):
+    def __getitem__(self, index_or_key: Union[int, str]): # type: ignore
         """Returns an item by index or key."""
-        if index_or_key in self.keys():
+        if isinstance(index_or_key, str) and index_or_key in self.keys():
             return getattr(self, index_or_key)
 
-        # Explicitely call to tuple, since
+        # Explicitly call to tuple, since
         # super() does not work in NamedTuples.
-        return tuple.__getitem__(self, index_or_key)
+        return tuple.__getitem__(self, index_or_key) # type: ignore
 
     def __mul__(self, other):
         if isinstance(other, Vec3):

--- a/mcwb/volume.py
+++ b/mcwb/volume.py
@@ -101,7 +101,7 @@ class Volume:
             profile = [[block] * int(self.size.x)] * int(self.size.y)
             make_tunnel(
                 client,
-                profile,
+                profile, # type: ignore
                 self.start,
                 direction=Direction.UP,
                 anchor=Anchor.BOTTOM_LEFT,

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,15 @@ long_description_content_type = text/markdown
 keywords = minecraft world builder python rcon
 classifiers =
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.13
 
 [options]
 packages = find:
 
 install_requires =
     numpy
-    mcipc>=2.4.2
-    rcon>=2.3.6
+    mcipc
+    rcon
 
 [options.packages.find]
 # Don't include our tests directory in the distribution
@@ -27,11 +27,11 @@ exclude = tests
 [options.extras_require]
 # For development tests/docs
 dev =
-    black==21.10b0
+    black
     isort
     pytest-cov
     pytest-mypy
-    flake8<3.9.3
+    flake8
     pytest-flake8
     pytest-black
     flake8-isort
@@ -57,10 +57,15 @@ skip=setup.py,conf.py,build
 [flake8]
 # Make flake8 respect black's line length (default 88),
 max-line-length = 88
+# Note flake8's parser now breaks if you have comments on the same lines
+# See https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30
 extend-ignore =
-    E203, # See https://github.com/PyCQA/pycodestyle/issues/373
-    F811, # support typing.overload decorator
-    F722, # allow Annotated[typ, some_func("some string")]
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,
+    # support typing.overload decorator
+    F811,
+    # allow Annotated[typ, some_func("some string")]
+    F722,
 # exclude =
 
 [tool:pytest]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -68,7 +68,7 @@ class TestOffsets(TestCase):
             [Item.AIR, Item.AIR, Item.AIR],
             [Item.BLUE_CONCRETE, Item.AIR, Item.YELLOW_CONCRETE],
         ]
-        self.directions = Direction.all
+        self.directions = Direction.all()
         self.anchors = Anchor
         self.results = [
             [


### PR DESCRIPTION
To quote the python docs:
Deprecated since version 3.11, removed in version 3.13: Class methods can no longer wrap other [descriptors](https://docs.python.org/3/glossary.html#term-descriptor) such as [property()](https://docs.python.org/3/library/functions.html#property).

Note: I pulled from the 2024 fixes branch as it seems to be where the last beta release I'm using came from and this also merges that change